### PR TITLE
Remove the updated_at

### DIFF
--- a/source/trunk/db.ts
+++ b/source/trunk/db.ts
@@ -47,27 +47,25 @@ export const updateCocoaDocsRowForPod = async (row: CocoaDocsRow) => {
   const existingRow = await trunk.query(existsQuery, existsValues)
   if (existingRow.rowCount) {
     // Update if it exists
-    const insertQuery = `UPDATE cocoadocs_pod_metrics SET "rendered_readme_url"=$1, "rendered_changelog_url"=$2, "license_short_name"=$3, "license_canonical_url"=$4, "updated_at"=$5 WHERE "id"=$6`
+    const insertQuery = `UPDATE cocoadocs_pod_metrics SET "rendered_readme_url"=$1, "rendered_changelog_url"=$2, "license_short_name"=$3, "license_canonical_url"=$4, WHERE "id"=$5`
     const insertValues = [
       row.rendered_readme_url,
       row.rendered_changelog_url,
       row.license_short_name,
       row.license_canonical_url,
-      (new Date()).toISOString(),
       existingRow.rows[0].id
     ]
     await trunk.query(insertQuery, insertValues)
   } else {
     // Create if it doesn't exist
     const insertQuery =
-      "INSERT INTO cocoadocs_pod_metrics(pod_id, rendered_readme_url, rendered_changelog_url, license_short_name, license_canonical_url, updated_at) VALUES($1::int, $2::text, $3::text, $4::text, $5::text, $6::text)"
+      "INSERT INTO cocoadocs_pod_metrics(pod_id, rendered_readme_url, rendered_changelog_url, license_short_name, license_canonical_url) VALUES($1::int, $2::text, $3::text, $4::text, $5::text)"
     const insertValues = [
       podID,
       row.rendered_readme_url,
       row.rendered_changelog_url,
       row.license_short_name,
       row.license_canonical_url,
-      (new Date()).toISOString(),
     ]
     await trunk.query(insertQuery, insertValues)
   }


### PR DESCRIPTION
When I looked at the logs, there were a lot of 

> 2023-07-23T14:08:12.318106+00:00 heroku[router]: at=info method=POST path="/webhook/hooks/trunk/d286a7388ab9bddfdf5cb79300094e4d1f241b14" host=cocoapods-metadata-service.herokuapp.com request_id=49be6b42-4603-4557-bcd6-aa045d6abe2f fwd="34.229.86.1" dyno=web.1 connect=0ms service=11ms status=200 bytes=217 protocol=https
2023-07-23T14:08:12.904645+00:00 app[web.1]: [MobilliumToolTips - 0.1.0] Getting info on README, CHANGELOG and community metrics.Uncaught error: error: column "updated_at" is of type timestamp without time zone but expression is of type text

This removes the updated_at column - it's marked as nullable in the db, and it's not something we show anywhere